### PR TITLE
Bump ArduinoCore-API submodule to 1.5.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
       - "tests/**"
       - "builder/**"
       - "platform.json"
+      - "ArduinoCore-API"
+      - "libraries/WiFi"
   pull_request:
     branches:
       - main
@@ -23,6 +25,8 @@ on:
       - "tests/**"
       - "builder/**"
       - "platform.json"
+      - "ArduinoCore-API"
+      - "libraries/WiFi"
   workflow_dispatch:
 
 jobs:

--- a/tests/unit/test_linux_spi.cpp
+++ b/tests/unit/test_linux_spi.cpp
@@ -87,7 +87,7 @@ TEST_CASE("LinuxHardwareSPI::transfer16 returns 0 (not implemented)", "[spi][lin
 TEST_CASE("LinuxHardwareSPI::beginTransaction/endTransaction do not crash via sim", "[spi][linux]") {
     arduino::LinuxHardwareSPI spi;
     spi.begin();
-    arduino::SPISettings settings(1000000, MSBFIRST, SPI_MODE0);
+    arduino::SPISettings settings(1000000, MSBFIRST, arduino::SPI_MODE0);
     CHECK_NOTHROW(spi.beginTransaction(settings));
     CHECK_NOTHROW(spi.endTransaction());
     spi.end();

--- a/tests/unit/test_spi_stubs.cpp
+++ b/tests/unit/test_spi_stubs.cpp
@@ -62,7 +62,7 @@ TEST_CASE("HardwareSPI::notUsingInterrupt stub does not crash", "[spi][stubs]") 
 
 TEST_CASE("HardwareSPI::beginTransaction stub does not crash", "[spi][stubs]") {
     BareSPI spi;
-    CHECK_NOTHROW(spi.beginTransaction(arduino::SPISettings(1000000, MSBFIRST, SPI_MODE0)));
+    CHECK_NOTHROW(spi.beginTransaction(arduino::SPISettings(1000000, MSBFIRST, arduino::SPI_MODE0)));
 }
 
 TEST_CASE("HardwareSPI::endTransaction stub does not crash", "[spi][stubs]") {


### PR DESCRIPTION
Move ArduinoCore-API from 1.2.0 (2ca15ad) to 1.5.2 (cd91833). Source
required code changes: ArduinoAPI.h's include set is unchanged (new
CAN/DMAPool headers aren't pulled into the host compile), SPISettings'
added busMode is defaulted and we only use getters, Common.h's
OUTPUT_OPENDRAIN is additive with atexit still #ifndef HOST-guarded,
and the IPv6 IPAddress refactor only touches AsyncUDP/WiFi, neither of
which is compiled. We pick up the upstream print(0ULL) fix for free.

Also add the ArduinoCore-API and libraries/WiFi submodule paths to the
CI workflow filters; a gitlink-only bump matches none of the existing
paths, so CI would otherwise not run on submodule-bump PRs.

Addresses the ArduinoCore-API half of #12. WiFi and #10 are out of scope.
