### PR TITLE
Default LinuxHardwareI2C fd to -1 (fix Wire-on-stdin hang)

### DIFF
--- a/cores/ardulinux/linux/LinuxHardwareI2C.h
+++ b/cores/ardulinux/linux/LinuxHardwareI2C.h
@@ -38,7 +38,7 @@ namespace arduino {
  * variables declared in LinuxHardwareI2C.cpp.  Not thread-safe.
  */
 class LinuxHardwareI2C : public HardwareI2C {
-  int i2c_file = 0; ///< File descriptor for the open i2c-dev device
+  int i2c_file = -1; ///< File descriptor; -1 until begin() opens the i2c-dev device (so reads/writes fail fast instead of hitting stdin/stdout)
 
 public:
   /**

--- a/tests/unit/test_linux_i2c.cpp
+++ b/tests/unit/test_linux_i2c.cpp
@@ -33,8 +33,7 @@ namespace arduino {
 
 TEST_CASE("LinuxHardwareI2C::requestFrom returns error when fd is invalid", "[i2c][linux]") {
     // Pre-populate a TX byte so requestFrom takes the combined write-read path
-    // (ioctl I2C_RDWR).  That path fails immediately on fd 0 (stdin) without
-    // blocking, unlike the simple-read path which calls ::read() and would block.
+    // (ioctl I2C_RDWR), which fails immediately on the unopened fd (-1 -> EBADF).
     arduino::requestedBytes = 1;
     arduino::TXbuf[0] = 0x10;
 
@@ -42,7 +41,7 @@ TEST_CASE("LinuxHardwareI2C::requestFrom returns error when fd is invalid", "[i2
     // and the requestFrom function entry in LinuxHardwareI2C.cpp.
     size_t result = arduino::Wire.requestFrom((uint8_t)0x42, (size_t)4);
 
-    // ioctl(I2C_RDWR) on stdin fails; 0 is returned (not the requested count).
+    // ioctl(I2C_RDWR) on the unopened fd fails; 0 is returned (not the requested count).
     CHECK(result == (size_t)0);
 
     arduino::requestedBytes = 0;  // reset for subsequent tests
@@ -76,8 +75,8 @@ TEST_CASE("LinuxHardwareI2C::available returns remaining byte count from RX buff
     arduino::Wire.read();
     CHECK(arduino::Wire.available() == 1);
     arduino::Wire.read();
-    // Buffer exhausted; available() falls through to ioctl(FIONREAD) which
-    // returns 0 for fd 0 (stdin, no data pending).
+    // Buffer exhausted; available() falls through to ioctl(FIONREAD) on the
+    // unopened fd (-1), which fails and leaves the count at 0.
     CHECK(arduino::Wire.available() == 0);
 }
 


### PR DESCRIPTION
LinuxHardwareI2C::i2c_file defaulted to 0, so before begin() the global
Wire operated on fd 0/1 (stdin/stdout). read()/requestFrom() then issued a
blocking ::read(0, ...) that hangs on an interactive terminal waiting for
keystrokes; available()/endTransmission similarly touched stdin/stdout.
LinuxSerial already uses -1 for exactly this reason.

This surfaced as ctest hanging on the i2c underflow-guard test
(test_linux_i2c.cpp #186) on any machine with libgpiod installed — CI never
hit it because its stdin is /dev/null (::read returns EOF instantly).

Default i2c_file to -1 so an unopened Wire fails fast (EBADF). All i2c tests
still pass (ioctl/-1 and ::read/-1 fail cleanly → available()=0, read()=-1)
and the hang is gone. Updates the now-stale "fd 0 (stdin)" test comments.

