### PR TITLE
Add keywords and authors to platform.json

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -3,8 +3,14 @@
   "version": "0.2.0",
   "title": "ArduLinux",
   "description": "ArduLinux - Arduino API for Linux",
+  "keywords": ["arduino", "linux", "native", "posix", "gpio", "spi", "i2c", "portduino"],
   "homepage": "https://github.com/l5yth/ardulinux",
   "license": "LGPL-2.1-or-later",
+  "authors": {
+    "name": "l5yth",
+    "url": "https://github.com/l5yth",
+    "maintainer": true
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/l5yth/ardulinux"


### PR DESCRIPTION
Registry-discoverability fields for the 0.2.0 publish: keywords (lowercase,
per PlatformIO's charset rules) and an authors entry (no email set; add one
if desired).

