### PR TITLE
Docs: fix fresh-clone build, document tests, CLI flags, and app identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,47 @@ framework = arduino
 board = ardulinux
 ```
 
-libgpiod and libi2c are detected automatically via `pkg-config` — no extra flags required. Without libgpiod the build falls back to simulated GPIO and I2C, which works without any hardware.
+Hardware support is gated on **libgpiod**: if `pkg-config` finds it, real GPIO/I2C are compiled in — this also links **libi2c**, so install the two together. If libgpiod is absent, the build uses fully simulated GPIO/I2C and needs no hardware libraries.
 
 ## Building standalone (CMake)
 
-Requires GCC or Clang (C++14), CMake 3.17+, and pkg-config. libgpiod and libi2c are optional; without them the build uses simulated devices.
+Requires GCC or Clang (C++14), CMake 3.17+, and pkg-config. Hardware GPIO/I2C are enabled when libgpiod is detected; libgpiod also requires libi2c, so install both together (or neither, for a simulated build).
 
-On Debian/Ubuntu:
+ArduinoCore-API and WiFi are git submodules — clone with them, or initialise them after cloning:
+```sh
+git clone --recurse-submodules https://github.com/l5yth/ardulinux.git
+# already cloned?  →  git submodule update --init --recursive
+```
+
+Install the build dependencies — on Debian/Ubuntu:
 ```sh
 sudo apt-get install build-essential cmake libgpiod-dev libi2c-dev pkg-config
 ```
-
 On Arch:
 ```sh
 sudo pacman -S base-devel cmake libgpiod i2c-tools pkg-config
 ```
 
+Configure and build:
 ```sh
 cmake -B build
 cmake --build build
+./build/ArduLinux --help
 ```
+
+To force a simulated build on a machine that *has* libgpiod installed, hide it from pkg-config with an empty `PKG_CONFIG_LIBDIR` (an empty `PKG_CONFIG_PATH` is not enough):
+```sh
+PKG_CONFIG_LIBDIR= cmake -B build-sim
+cmake --build build-sim
+```
+
+### Running the tests
+
+```sh
+ctest --test-dir build --output-on-failure
+```
+
+The unit tests use Catch2 (fetched automatically at configure time). The I2C hardware tests are built only when libgpiod and libi2c are present.
 
 ## Writing an application
 
@@ -68,7 +89,31 @@ void loop() {
 }
 ```
 
-Without `ardulinuxSetup()`, all pins default to simulated. The VFS is mounted at `~/.ardulinux/default/` by default; pass `--fsdir <path>` to override or `--erase` to wipe it on startup.
+Without `ardulinuxSetup()`, all pins default to simulated. All `Print`/`Stream` subclasses (`Serial`, `File`, …) also provide a `printf()` method on top of the standard `print()`/`println()`.
+
+### Command-line options
+
+The built application accepts:
+
+| Option | Description |
+| --- | --- |
+| `-d`, `--fsdir DIR` | Use `DIR` as the virtual filesystem root. |
+| `-e`, `--erase` | Wipe the virtual filesystem before startup. |
+| `-V`, `--version` | Print the program name and version. |
+| `-?`, `--help` / `--usage` | Show the help / usage message. |
+
+The VFS root defaults to `$XDG_DATA_HOME/<app>/default` (i.e. `~/.local/share/ardulinux/default/`); `--fsdir` overrides it.
+
+### Customizing program identity
+
+The platform reads four optional weak symbols. Define any of them as plain (non-weak) definitions in an application source file to override the defaults — no header required:
+
+```cpp
+const char *ardulinuxAppName        = "meshcored";                          // startup msg, VFS dir, libgpiod label (default "ardulinux")
+const char *ardulinuxAppVersion     = "1.14.1-linux";                       // shown by --version (default: FIRMWARE_VERSION or "unknown")
+const char *ardulinuxAppDescription = "Radio mesh daemon";                  // shown in --help
+const char *ardulinuxAppBugAddress  = "https://github.com/myorg/myapp/issues"; // "Report bugs to" line in --help
+```
 
 ## License
 

--- a/example/README.md
+++ b/example/README.md
@@ -6,7 +6,7 @@
 2. GCC (`sudo apt-get install build-essential` or equivalent).
 3. PlatformIO — see https://platformio.org/install for instructions.
 
-libgpiod (`libgpiod-dev`) is optional. If present, Linux hardware GPIO and I2C are compiled in automatically. Without it the build falls back to simulated devices.
+Hardware support is gated on libgpiod: if it is present, Linux GPIO and I2C are compiled in automatically (this also requires libi2c — `libi2c-dev` on Debian/Ubuntu, `i2c-tools` on Arch). Without libgpiod the build uses simulated devices.
 
 ### Build
 
@@ -15,7 +15,7 @@ cd example
 pio run
 ```
 
-The `platformio.ini` uses `platform = symlink://../` which points at the ArduLinux platform root — no separate install required when working inside this repository.
+The `platformio.ini` uses `platform = symlink://../` which points at the ArduLinux platform root — no separate install required when working inside this repository. Initialise the platform's submodules first (`git submodule update --init --recursive` from the repo root), otherwise the core sources are missing and the build fails.
 
 To consume ArduLinux from a project outside this repository, replace the `platform` line with the git URL:
 


### PR DESCRIPTION
Reviewed README/example against a from-scratch setup:
- Add the missing submodule-init step to the standalone CMake build and the
  example — a plain `git clone` leaves cores/arduino/api dangling, so the
  build fails on missing sources.
- Correct the "falls back to simulated" wording: detection is gated on
  libgpiod (which also links libi2c), so libgpiod-without-libi2c is a hard
  link failure, not a fallback. Document PKG_CONFIG_LIBDIR= to force a
  simulated build when libgpiod is installed.
- Document `ctest` for the unit suite (and that the I2C tests need libgpiod).
- Add a CLI options table and the ardulinuxApp* weak symbols; note Serial
  printf().
- Fix the default VFS path: XDG (~/.local/share/<app>/default), not the stale
  ~/.ardulinux/default.

