### PR TITLE
Gate Wire.h on ARDULINUX_HARDWARE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ target_include_directories(ardulinux-base PUBLIC
         cores/arduino/api
         cores/ardulinux
         cores/ardulinux/FS
+        libraries/Wire/src
 )
 
 # ArduinoCore-API's Common.h re-declares atexit() without noexcept, which conflicts

--- a/example/src/test.cpp
+++ b/example/src/test.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "Arduino.h"
+#include <Wire.h>
 
 #define TEST_PIN 7
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -1,3 +1,6 @@
 #pragma once
+#ifdef ARDULINUX_HARDWARE
 #include "linux/LinuxHardwareI2C.h"
-// FIXME - move wire code here?
+#else
+#include "simulated/SimHardwareI2C.h"
+#endif

--- a/platform.json
+++ b/platform.json
@@ -1,6 +1,6 @@
 {
   "name": "ardulinux",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "title": "ArduLinux",
   "description": "ArduLinux - Arduino API for Linux",
   "keywords": ["arduino", "linux", "native", "posix", "gpio", "spi", "i2c", "portduino"],


### PR DESCRIPTION
cores/ardulinux/Arduino.h switches the I²C header on
ARDULINUX_HARDWARE, but libraries/Wire/src/Wire.h was
unconditionally pulling in linux/LinuxHardwareI2C.h. On hosts
without libgpiod (e.g. dietpi/trixie), Arduino.h declares
extern arduino::SimHardwareI2C Wire and Wire.h follows with
extern arduino::LinuxHardwareI2C Wire — same TU, build fails:

    LinuxHardwareI2C.h:181:25: error: conflicting declaration
    'arduino::LinuxHardwareI2C arduino::Wire'
    note: previous declaration as 'arduino::SimHardwareI2C arduino::Wire'

Mirror the Arduino.h conditional and drop the stale FIXME.

Add #include <Wire.h> to example/src/test.cpp so the pio CI job
(runner has no libgpiod-dev) actually drags Wire.h into the TU
and guards against a regression.

Fix https://github.com/l5yth/meshcore-linux/issues/11
